### PR TITLE
Fix user events not taking previous state user data into account

### DIFF
--- a/js/server/process-vs.js
+++ b/js/server/process-vs.js
@@ -44,7 +44,7 @@ function processUserTickets(users, globalRewardAccrued) {
 function processUserEvents(users, eventsByUser) {
   _.forEach(eventsByUser, userEvents => {
     userEvents.forEach(event => {
-      const user = eventsByUser[event.delegateAddress][event.address] || {
+      const user = users[event.delegateAddress] || {
         tickets: [],
         claimed: 0,
         dispensed: 0,


### PR DESCRIPTION
It was trying to get the user from eventsByUser but there is no user data there.

The user data is from `users` map.

This fixes burning or adding tickets never taking previous state into account. This most commonly manifested itself in ticket-burning setting user.tickets to empty, instead of burning tickets based on previous user state.