### PR TITLE
Add getTimeIndex to userData query on vs api

### DIFF
--- a/js/server/main.js
+++ b/js/server/main.js
@@ -71,7 +71,11 @@ app.get('/api/vs', async (req, res, next) => {
     }
     case 'userData': {
       const address = req.query.address;
-      responseJSON = await activeProcess.dispatch('GET_VS_USER_DATA', address);
+      const timeIndex = getTimeIndex(req.query.timestamp);
+      responseJSON = await activeProcess.dispatch('GET_VS_USER_DATA', {
+        address,
+        timeIndex
+      });
       break;
     }
     case 'stack': {


### PR DESCRIPTION
I checked `GET_VS_USER_DATA` dispatcher and it's expecting `{address, timeIndex}` so it should all just work.