### PR TITLE
Preserve ticket.multiplier upon redelegation

### DIFF
--- a/js/server/process-vs.js
+++ b/js/server/process-vs.js
@@ -63,11 +63,16 @@ function processUserEvents (users, eventsByUser) {
       users[event.valSifAddress] = validator;
       validator.commisionClaimed = validator.commisionClaimed || 0;
       if (event.amount > 0) {
+        const isRedelegation = userEvents.some(other => {
+          return other.amount === -event.amount;
+        });
+        const redelegatedTicket =
+          isRedelegation && user.tickets.find(t => t.amount === event.amount);
         const newTicket = {
           commision: event.commision,
           valSifAddress: event.valSifAddress,
           amount: event.amount,
-          mul: 0.25,
+          mul: redelegatedTicket ? redelegatedTicket.mul : 0.25,
           reward: 0,
           timestamp: moment
             .utc(START_DATETIME)

--- a/js/server/process-vs.js
+++ b/js/server/process-vs.js
@@ -63,9 +63,11 @@ function processUserEvents (users, eventsByUser) {
       users[event.valSifAddress] = validator;
       validator.commisionClaimed = validator.commisionClaimed || 0;
       if (event.amount > 0) {
-        const isRedelegation = userEvents.some(other => {
-          return other.amount === -event.amount;
-        });
+        const isRedelegation =
+          userEvents.length > 1 &&
+          userEvents.some(other => {
+            return other.amount === -event.amount;
+          });
         const redelegatedTicket =
           isRedelegation && user.tickets.find(t => t.amount === event.amount);
         const newTicket = {

--- a/js/server/process-vs.js
+++ b/js/server/process-vs.js
@@ -46,6 +46,10 @@ function processUserTickets (users, globalRewardAccrued) {
 
 function processUserEvents (users, eventsByUser) {
   _.forEach(eventsByUser, userEvents => {
+    const previousUser =
+      userEvents.length > 0 && users[userEvents[0].delegateAddress];
+    const previousTickets = previousUser ? previousUser.tickets : [];
+
     userEvents.forEach(event => {
       const user = users[event.delegateAddress] || {
         tickets: [],
@@ -69,7 +73,8 @@ function processUserEvents (users, eventsByUser) {
             return other.amount === -event.amount;
           });
         const redelegatedTicket =
-          isRedelegation && user.tickets.find(t => t.amount === event.amount);
+          isRedelegation &&
+          previousTickets.find(t => t.amount === event.amount);
         const newTicket = {
           commision: event.commision,
           valSifAddress: event.valSifAddress,


### PR DESCRIPTION
Assuming that my check for whether this is a redelegation is accurate (can we just check `-amount === amount`?) then this should work in all cases.


Works on the case here: https://sifchain.slack.com/archives/G01LD7QNZ35/p1620696368409500