### PR TITLE
Fix Redelegation Bug + Commissions on Withdrawals + Commission Accrual + Rewards + Ticket Burning, Add Zoom to Chart

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,0 @@
-# Claims Todo
-
-- []

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,3 @@
+# Claims Todo
+
+- []

--- a/js/package.json
+++ b/js/package.json
@@ -10,6 +10,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "chart.js": "^3.2.1",
+    "chartjs-plugin-zoom": "^1.0.0",
     "cors": "^2.8.5",
     "cross-fetch": "^3.1.4",
     "d3": "^6.7.0",

--- a/js/server/augmentVSData.js
+++ b/js/server/augmentVSData.js
@@ -4,29 +4,7 @@ const { START_DATETIME } = require('./config');
 const { GlobalTimestampState, User } = require('./types');
 
 exports.augmentVSData = (globalTimestampStates) => {
-  globalTimestampStates.forEach((state) => {
-    state.users = _.forEach(state.users, (user, delegatorSifAddress) => {
-      /*
-        Must be run first on every user because delegators
-        store validators' addresses as references (and vice-versa) to be used in
-        `User(Validator)#recalculateTotalClaimableCommissionsOnDelegatorRewards`
-        via the user getter function passed as a callback.
-
-        If `User#recalculateTotalClaimableCommissionsOnDelegatorRewards` is run
-        immediately after this, within this loop iteration, it will only
-        account for delegate rewards on delegates that were processed before it
-        and leave out all those processed after.
-      */
-      user.collectValidatorsCommissionsOnLatestUnclaimedRewards(
-        (validatorSifAddress) => {
-          return state.users[validatorSifAddress];
-        },
-        delegatorSifAddress
-      );
-    });
-  });
-
-  globalTimestampStates.forEach((state) => {
+  globalTimestampStates.forEach((state, stateIndex) => {
     const timestampTicketsAmountSum = _.sum(
       _.map(state.users, (user) => {
         return _.sum(user.tickets.map((t) => t.amount));
@@ -35,18 +13,10 @@ exports.augmentVSData = (globalTimestampStates) => {
     state.totalTicketsAmountSum = timestampTicketsAmountSum;
     _.forEach(state.users, (user, address) => {
       /*
-        used to calculate ROI stats (APY, yield, etc.)
-        in `User#updateRewards`
-      */
-      user.recalculateTotalClaimableCommissionsOnDelegatorRewards(
-        (addr) => state.users[addr],
-        address
-      );
-      /*
         Must be run on every user before `User#updateUserMaturityRewards`
         `User#updateUserMaturityRewards` uses the rewards calulated here.
-        Must be run after `User#recalculateTotalClaimableCommissionsOnDelegatorRewards`
-        because `User#updateRewards` uses `User.totalClaimableCommissionsOnDelegatorRewards`,
+        Must be run after `User#recalculateCurrentTotalCommissionsOnClaimableDelegatorRewards`
+        because `User#updateRewards` uses `User.currentTotalCommissionsOnClaimableDelegatorRewards`,
         which is calculated in the former method.
       */
       user.updateRewards(timestampTicketsAmountSum);

--- a/js/server/types/UserTicket.js
+++ b/js/server/types/UserTicket.js
@@ -13,18 +13,68 @@ class UserTicket {
     this.commissionRewardsByValidator = {};
   }
 
+  calculateTotalValidatorCommissions () {
+    let sum = 0;
+    for (let prop in this.commissionRewardsByValidator) {
+      sum += this.commissionRewardsByValidator[prop];
+    }
+    return sum;
+  }
+
   static fromJSON (props) {
     return Object.assign(new this(), props);
+  }
+
+  burn (amountToBurn) {
+    if (amountToBurn < 0) {
+      throw new Error('amountToBurn must be a non-negative number');
+    }
+    if (amountToBurn > this.amount) {
+      throw new Error(
+        'amountToBurn must be less than or equal to `UserTicket.amount`'
+      );
+    }
+    const ratioToBurn = this.amount === 0 ? 0 : amountToBurn / this.amount;
+    const ratioToKeep = 1 - ratioToBurn;
+    const hasRemainder = ratioToBurn !== 1;
+    const burnedTicket = this.cloneWith({
+      amount: this.amount * ratioToBurn,
+      reward: this.reward * ratioToBurn,
+      rewardDelta: this.rewardDelta * ratioToBurn,
+      poolDominanceRatio: this.poolDominanceRatio * ratioToBurn,
+      commissionRewardsByValidator: Object.fromEntries(
+        Object.entries(this.commissionRewardsByValidator).map(([k, v]) => {
+          return [k, v * ratioToBurn];
+        })
+      )
+    });
+    let remainderTicket = null;
+    if (hasRemainder) {
+      remainderTicket = this.cloneWith({
+        amount: this.amount * ratioToKeep,
+        reward: this.reward * ratioToKeep,
+        rewardDelta: this.rewardDelta * ratioToKeep,
+        poolDominanceRatio: this.poolDominanceRatio * ratioToKeep,
+        commissionRewardsByValidator: Object.fromEntries(
+          Object.entries(this.commissionRewardsByValidator).map(([k, v]) => {
+            return [k, v * ratioToKeep];
+          })
+        )
+      });
+    }
+    return {
+      burnedTicket,
+      remainderTicket,
+      hasRemainder
+    };
   }
 
   cloneWith (props) {
     let next = new UserTicket();
     next = Object.assign(Object.assign(next, this), props);
-    if (props.commissionRewardsByValidator) {
-      next.commissionRewardsByValidator = {
-        ...next.commissionRewardsByValidator
-      };
-    }
+    next.commissionRewardsByValidator = {
+      ...next.commissionRewardsByValidator
+    };
     return next;
   }
 
@@ -41,13 +91,23 @@ class UserTicket {
     return currentClaims * this.mul;
   }
 
-  static fromEvent (event, mul) {
+  getForfeitedCommissionRewardByValidator (validatorSifAddress) {
+    let currentClaims =
+      this.commissionRewardsByValidator[validatorSifAddress] || 0;
+    return currentClaims * (1 - this.mul);
+  }
+
+  resetCommissionRewardsByValidator (validatorSifAddress) {
+    this.commissionRewardsByValidator[validatorSifAddress] = 0;
+  }
+
+  static fromEvent (event) {
     let instance = new this();
     Object.assign(instance, {
       commission: event.commission,
       validatorSifAddress: event.validatorSifAddress,
       amount: event.amount,
-      mul,
+      mul: 0.25,
       reward: 0,
       timestamp: moment
         .utc(config.START_DATETIME)

--- a/js/server/util/vs-util.js
+++ b/js/server/util/vs-util.js
@@ -29,7 +29,7 @@ function remapVSAddresses (vaLAddresses, timeInterval) {
               if (commissionRate < 0) {
                 console.log('COMMISSION RATE < 0. NEEDS HANDLING');
               }
-              return Object.assign(new DelegateEvent(), {
+              return DelegateEvent.fromJSON({
                 timestamp: (index + 1) * timeInterval,
                 commission: commissionRate,
                 amount,

--- a/js/src/DataChart.js
+++ b/js/src/DataChart.js
@@ -2,10 +2,12 @@ import React, { useEffect, useRef, useState } from 'react';
 import { timestampToDate } from './utils';
 import { Chart, _adapters, registerables } from 'chart.js';
 import { registerChartDateAdapter } from './registerChartDateAdapter';
+import zoomPlugin from 'chartjs-plugin-zoom';
+
 // let margin = { top: 10, right: 30, bottom: 30, left: 60 };
 // let width = 860 - margin.left - margin.right;
 // let height = 400 - margin.top - margin.bottom;
-Chart.register(...registerables);
+Chart.register(...registerables, zoomPlugin);
 registerChartDateAdapter(_adapters);
 
 export default props => {
@@ -26,6 +28,7 @@ export default props => {
   return (
     <div className='chart-container'>
       <canvas
+        onClick={() => chart.resetZoom()}
         className='chart'
         ref={myRef}
         id='myChart'
@@ -112,7 +115,18 @@ function renderChart (canvasElement, data, chart) {
         intersect: false
       },
       plugins: {
-        legend: false
+        legend: false,
+        zoom: {
+          zoom: {
+            wheel: {
+              enabled: true
+            },
+            pinch: {
+              enabled: true
+            },
+            mode: 'x'
+          }
+        }
       },
       scales: {
         x: {

--- a/js/src/StatBlocks.jsx
+++ b/js/src/StatBlocks.jsx
@@ -56,6 +56,31 @@ export const StatBlocks = {
     get totalTickets() {
       return this.totalTicketsAmountSum;
     },
+    // delegatorAddresses: createStatBlock({
+    //   title: 'Delegators',
+    //   subtitle: 'Addresses',
+    //   prefix: null,
+    //   data(data) {
+    //     return (
+    //       <div style={{ fontSize: '1rem' }}>
+    //         <details>
+    //           <summary>Click to Expand</summary>
+    //           <p>
+    //             {data.map((d) => {
+    //               return (
+    //                 <p key={d}>
+    //                   <a target="_blank" href={`/#${d}&type=vs`}>
+    //                     {d}
+    //                   </a>
+    //                 </p>
+    //               );
+    //             })}
+    //           </p>
+    //         </details>
+    //       </div>
+    //     );
+    //   },
+    // }),
   },
   lm: {
     ...defaultStatBlocks,

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -3325,6 +3325,13 @@ chart.js@^3.2.1:
   resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.2.1.tgz#1a17d6a88cef324ef711949e227eb51d6c4c26d3"
   integrity sha512-XsNDf3854RGZkLCt+5vWAXGAtUdKP2nhfikLGZqud6G4CvRE2ts64TIxTTfspOin2kEZvPgomE29E6oU02dYjQ==
 
+chartjs-plugin-zoom@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chartjs-plugin-zoom/-/chartjs-plugin-zoom-1.0.0.tgz#2286cd693d128f25e9eae80ba69b519ce037e5af"
+  integrity sha512-s3RzniiRcMoYmk6tLdPBGZXZB26ohDlRprgUDlfGnhq/bz1x+SczxiZzjIFN7UvNV6AGfSLdAhVaB/VSP9xs7Q==
+  dependencies:
+    hammerjs "^2.0.8"
+
 check-types@^11.1.1:
   version "11.1.2"
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-11.1.2.tgz#86a7c12bf5539f6324eb0e70ca8896c0e38f3e2f"
@@ -6113,6 +6120,11 @@ gzip-size@5.1.1:
   dependencies:
     duplexer "^0.1.1"
     pify "^4.0.1"
+
+hammerjs@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
+  integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
 
 handle-thing@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
# Summary
* Fixed bug causing random tickets to be burned on redelegation
* Fixed bug that applied the newest commission rate to all previous rewards
* Added deep cloning for `UserTicket.commissionRewardsByValidator`
* Added logic to partially burn all relative value properties on partially burned tickets, and do the inverse for the remainder on remainder tickets
* Added Chart zoom plugin (makes precise debugging easier) (click graph to reset zoom)
* Moved invocation of commissions logic to processor function
* Fixed `User#updateRewards` to properly handle commissions
* Added `User.claimableCommissions` to accumulate commissions from withdrawn tickets