### PR TITLE
Implement Redelegative Ticket Merging

### DIFF
--- a/js/server/process-vs.js
+++ b/js/server/process-vs.js
@@ -117,7 +117,6 @@ function processUserEvents (users, eventsByUser) {
         const redelegateWithdrawalEvent = wEvent.cloneWith({
           amount: amountOfWithdrawalToRedelegate
         });
-        // Burn the deposit amount
         const {
           burnedTickets: burnedTicketsForRedelegation
         } = user.removeBurnedTickets(redelegateWithdrawalEvent);

--- a/js/server/types/User.js
+++ b/js/server/types/User.js
@@ -236,7 +236,10 @@ class User {
 
   withdrawStakeAsDelegator (delegateEvent, getUserByAddress, burnedTickets) {
     if (!burnedTickets) {
-      burnedTickets = this.removeBurnedTickets(delegateEvent);
+      let { burnedTickets: newBurnedTickets } = this.removeBurnedTickets(
+        delegateEvent
+      );
+      burnedTickets = newBurnedTickets;
     }
     const { claimable, forfeited } = this.calculateClaimableReward(
       burnedTickets
@@ -341,7 +344,7 @@ class User {
       }
     });
     this.tickets = otherValidatorTickets.concat(remainingTickets);
-    return burnedTickets;
+    return { burnedTickets, remainder: remainingWithdrawalAmount };
   }
 }
 module.exports = { User };

--- a/js/server/types/UserTicket.js
+++ b/js/server/types/UserTicket.js
@@ -79,6 +79,14 @@ class UserTicket {
     return next;
   }
 
+  cloneAndRedelegateFromEvent (event) {
+    return this.cloneWith({
+      commission: event.commission,
+      validatorRewardAddress: event.validatorRewardAddress,
+      validatorStakeAddress: event.validatorStakeAddress
+    });
+  }
+
   addCommissionRewardByValidator (commissionReward, validatorRewardAddress) {
     let currentClaims =
       this.commissionRewardsByValidator[validatorRewardAddress] || 0;

--- a/js/server/user.js
+++ b/js/server/user.js
@@ -21,7 +21,6 @@ exports.getUserTimeSeriesData = (all, address) => {
 };
 
 exports.getUserData = async (all, { timeIndex, address }) => {
-  console.log({ timeIndex });
   if (!timeIndex) {
     const data = all.map(timestampGlobalState => {
       let user = timestampGlobalState.users[address];

--- a/js/src/UserDataSummary.jsx
+++ b/js/src/UserDataSummary.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 
 const numFormatter = new Intl.NumberFormat();
 
-const styleData = (data) => ({
+const styleData = data => ({
   __styled: true,
-  data,
+  data
 });
 const say = (template, ...substitutions) => {
   // if (!substitutions.every((s) => !!s)) {
   //   return null;
   // }
-  return template.map((str) => {
+  return template.map(str => {
     let item = substitutions.shift();
     const isStyled = item && item.__styled;
     item = isStyled ? item.data : item;
@@ -72,7 +72,7 @@ export const UserDataSummary = ({ user, type = 'vs' }) => {
       : null;
   return (
     <div style={{ width: '100%', padding: '0% 0%' }}>
-      <div className="user-data-summary-container">
+      <div className='user-data-summary-container'>
         <div style={{}}>
           {stakerText}
           {stakerText2}

--- a/js/src/UserDataSummary.jsx
+++ b/js/src/UserDataSummary.jsx
@@ -54,13 +54,13 @@ export const UserDataSummary = ({ user, type = 'vs' }) => {
   )} rowan in commissions will be claimable when they reach maturity or when their respective delegators claim their rewards.`}`}
       </div>
     ) : null;
-  const stakerText = say`Thanks to your total ${
-    type === 'vs' ? 'stake' : 'pool contribution'
-  } of ${user.totalDepositedAmount} rowan, you can claim ${styleData(
+  const stakerText = say`You are currently ${
+    type === 'vs' ? 'staking' : 'pooling'
+  } ${user.totalDepositedAmount} rowan and you can claim ${styleData(
     user.totalClaimableRewardsOnDepositedAssets +
       user.claimableRewardsOnWithdrawnAssets
   )} rowan in rewards today. `;
-  const stakerText2 = say`${
+  const stakerText2 =
     user.reservedReward > user.totalClaimableRewardsOnDepositedAssets
       ? say`But if you wait until ${styleData(
           user.maturityDate
@@ -69,8 +69,7 @@ export const UserDataSummary = ({ user, type = 'vs' }) => {
         } rowan. ${say`(a projected APY of ${styleData(
           user.nextRewardProjectedAPYOnTickets * 100
         )}%)`}`
-      : null
-  }`;
+      : null;
   return (
     <div style={{ width: '100%', padding: '0% 0%' }}>
       <div className="user-data-summary-container">

--- a/js/src/api.js
+++ b/js/src/api.js
@@ -13,10 +13,14 @@ const serverURL = (() => {
   }
 })();
 
+function handleFailedRequest () {
+  window.location.reload();
+}
 export const fetchUsers = type => {
   return window
     .fetch(`${serverURL}/${type}?key=users`)
-    .then(response => response.json());
+    .then(response => response.json())
+    .catch(handleFailedRequest);
 };
 
 export const fetchUserData = (address, type, timestamp) => {
@@ -26,17 +30,20 @@ export const fetchUserData = (address, type, timestamp) => {
         timestamp ? `&timestamp=${new Date(timestamp).toISOString()}` : ``
       }`
     )
-    .then(response => response.json());
+    .then(response => response.json())
+    .catch(handleFailedRequest);
 };
 
 export const fetchUserTimeSeriesData = (address, type) => {
   return window
     .fetch(`${serverURL}/${type}?key=userTimeSeriesData&address=${address}`)
-    .then(response => response.json());
+    .then(response => response.json())
+    .catch(handleFailedRequest);
 };
 
 export const fetchStack = type => {
   return window
     .fetch(`${serverURL}/${type}?key=stack`)
-    .then(response => response.json());
+    .then(response => response.json())
+    .catch(handleFailedRequest);
 };


### PR DESCRIPTION
Below is an approximate summary of how redelegative ticket merging works. However, note that the map is not the territory and the actual implementation is more event-centric than described below.
* For each group of **_User_**'s events within a 200 minute interval
  * Determine **_Total Redelegation Amount_**:
    * Calculate total withdrawals 
    * Calculate total deposits
    * Select the smaller of the two
  * Determine **_Tickets To Redelegate_**: 
    * Burn **_Total Redelegation Amount_** from **_User_**'s tickets, as designated by withdrawal events
    * Aggregate burned tickets
  * If total withdrawal amount is greater than **_Total Redelegation Amount_**: 
    * Execute traditional withdrawals on the remainder
  * Optimize redelegations to maximize **_User_**'s long term gains
    * Match the **_Tickets To Redelegate_** with the highest remaining rewards with deposit events with the lowest commissions
  * Redelegate **_Tickets To Redelegate_**: 
    *  Redelegate tickets with commissions and validator addresses of their respective deposit events
    * Add redelegated tickets to **_User_**
   * If total deposit amount is greater than **_Total Redelegation Amount_**: 
     * Execute traditional deposits on the remainder

