### PR TITLE
Add Caching, Lazy Evaluation. Compute Time: -75%, Memory Usage: -50%

### DIFF
--- a/js/scripts/create-test-snapshot.js
+++ b/js/scripts/create-test-snapshot.js
@@ -1,5 +1,5 @@
 const {
-  loadValidatorsSnapshot
+  loadValidatorsSnapshot,
 } = require('../server/loaders/loadValidatorsSnapshot');
 
 const { fetch } = require('cross-fetch');
@@ -28,7 +28,7 @@ const serverURL = (() => {
     if (type === 'lm') continue;
     switch (type) {
       case 'vs': {
-        data = await loadValidatorsSnapshot();
+        data = await loadValidatorsSnapshot().then((r) => r.json());
         break;
       }
       case 'lm': {
@@ -41,7 +41,7 @@ const serverURL = (() => {
       `../snapshots/test.${type}.json`
     );
     const url = `${serverURL}/${type}`;
-    const users = await fetch(`${url}?key=users`).then(r => r.json());
+    const users = await fetch(`${url}?key=users`).then((r) => r.json());
 
     let topAddresses = users.slice(0, 5);
     data.data.snapshots_validators[0].snapshot_data = Object.fromEntries(

--- a/js/server/augmentVSData.js
+++ b/js/server/augmentVSData.js
@@ -4,87 +4,64 @@ const { START_DATETIME } = require('./config');
 const { GlobalTimestampState, User } = require('./types');
 
 exports.augmentVSData = globalTimestampStates => {
-  console.time('augment/updateRewards');
-  globalTimestampStates.forEach((state, stateIndex) => {
-    const timestampTicketsAmountSum = _.sum(
-      _.map(state.users, user => {
-        return _.sum(user.tickets.map(t => t.amount));
-      })
-    );
-
-    state.setTotalDepositedAmount(timestampTicketsAmountSum);
-
-    // can be lazy evaluated
-    _.forEach(state.users, (user, address) => {
-      /*
-        Must be run on every user before `User#updateUserMaturityRewards`
-        `User#updateUserMaturityRewards` uses the rewards calulated here.
-        Must be run after `User#recalculateCurrentTotalCommissionsOnClaimableDelegatorRewards`
-        because `User#updateRewards` uses `User.currentTotalCommissionsOnClaimableDelegatorRewards`,
-        which is calculated in the former method.
-      */
-      user.updateRewards(timestampTicketsAmountSum);
-    });
-  });
-  console.timeEnd('augment/updateRewards');
-
+  console.time('augmentVSData');
   const finalTimestampState =
     globalTimestampStates[globalTimestampStates.length - 1] ||
     new GlobalTimestampState();
 
-  console.time('augment/updateUserMaturityRewards');
-  // can be lazy evaluated
-  globalTimestampStates.forEach(timestamp => {
-    _.forEach(timestamp.users, (user, address) => {
-      const userAtMaturity = finalTimestampState.users[address] || new User();
-      user.updateUserMaturityRewards(userAtMaturity);
-    });
-  });
-  console.timeEnd('augment/updateUserMaturityRewards');
+  // console.time('augment/updateUserMaturityRewards');
+  // // can be lazy evaluated
+  // globalTimestampStates.forEach((timestamp) => {
+  //   _.forEach(timestamp.users, (user, address) => {
+  //     const userAtMaturity = finalTimestampState.users[address] || new User();
+  //     user.updateUserMaturityRewards(userAtMaturity);
+  //   });
+  // });
+  // console.timeEnd('augment/updateUserMaturityRewards');
 
-  console.time('augment/updateUserMaturityDates');
+  // console.time('augment/updateUserMaturityDates');
 
-  // can be lazy evaluated
-  globalTimestampStates.forEach((timestampState, timestampIndex) => {
-    _.forEach(timestampState.users, (user, address) => {
-      const prevTimestamp =
-        globalTimestampStates[timestampIndex - 1] || new GlobalTimestampState();
-      const userAtPrevTimestamp = prevTimestamp.users[address] || new User();
-      const isAfterRewardPeriod = timestampState.rewardBuckets.length === 0;
-      const currentTimestampInMinutes = timestampState.timestamp;
-      const nextBucketGlobalReward = timestampState.rewardBuckets.reduce(
-        (accum, bucket) => {
-          return accum + bucket.initialRowan / bucket.duration;
-        },
-        0
-      );
-      user.updateUserMaturityDates(
-        userAtPrevTimestamp,
-        isAfterRewardPeriod,
-        currentTimestampInMinutes,
-        nextBucketGlobalReward
-      );
-    });
-  });
-  console.timeEnd('augment/updateUserMaturityDates');
+  // // can be lazy evaluated
+  // globalTimestampStates.forEach((timestampState, timestampIndex) => {
+  //   _.forEach(timestampState.users, (user, address) => {
+  //     const prevTimestamp =
+  //       globalTimestampStates[timestampIndex - 1] || new GlobalTimestampState();
+  //     const userAtPrevTimestamp = prevTimestamp.users[address] || new User();
+  //     const isAfterRewardPeriod = timestampState.rewardBuckets.length === 0;
+  //     const currentTimestampInMinutes = timestampState.timestamp;
+  //     const nextBucketGlobalReward = timestampState.rewardBuckets.reduce(
+  //       (accum, bucket) => {
+  //         return accum + bucket.initialRowan / bucket.duration;
+  //       },
+  //       0
+  //     );
+  //     user.updateUserMaturityDates(
+  //       userAtPrevTimestamp,
+  //       isAfterRewardPeriod,
+  //       currentTimestampInMinutes,
+  //       nextBucketGlobalReward
+  //     );
+  //   });
+  // });
+  // console.timeEnd('augment/updateUserMaturityDates');
 
-  // fill in old timestamps with maturity date now that we have it
-  const lastTimestamp =
-    globalTimestampStates[globalTimestampStates.length - 1] ||
-    new GlobalTimestampState();
+  // // fill in old timestamps with maturity date now that we have it
+  // const lastTimestamp =
+  //   globalTimestampStates[globalTimestampStates.length - 1] ||
+  //   new GlobalTimestampState();
 
-  console.time('augment/updateMaturityTimeProps');
-  // can be lazy evaluated
-  globalTimestampStates.forEach(timestampState => {
-    const timestampDate = moment
-      .utc(START_DATETIME)
-      .add(timestampState.timestamp, 'm');
-    _.forEach(timestampState.users, (user, address) => {
-      const lastUser = lastTimestamp.users[address] || new User();
-      user.updateMaturityTimeProps(lastUser, timestampDate.valueOf());
-    });
-  });
-  console.timeEnd('augment/updateMaturityTimeProps');
+  // console.time('augment/updateMaturityTimeProps');
+  // // can be lazy evaluated
+  // globalTimestampStates.forEach((timestampState) => {
+  //   const timestampDate = moment
+  //     .utc(START_DATETIME)
+  //     .add(timestampState.timestamp, 'm');
+  //   _.forEach(timestampState.users, (user, address) => {
+  //     const lastUser = lastTimestamp.users[address] || new User();
+  //     user.updateMaturityTimeProps(lastUser, timestampDate.valueOf());
+  //   });
+  // });
+  // console.timeEnd('augment/updateMaturityTimeProps');
 
   const rewardBucketsTimeSeries = globalTimestampStates
     .map((timestampData, timestamp) => {
@@ -107,7 +84,7 @@ exports.augmentVSData = globalTimestampStates => {
   );
   const top50Users = _.orderBy(
     finalTimestampStateUsers,
-    ['totalRewardsOnDepositedAssetsAtMaturity'],
+    ['totalAccruedCommissionsAndClaimableRewards'],
     ['desc']
   ).slice(0, 50);
   const blankUserRewards = top50Users.reduce((accum, user) => {
@@ -135,11 +112,66 @@ exports.augmentVSData = globalTimestampStates => {
   const uniqueUserAddresses = _.uniq(
     _.flatten(globalTimestampStates.map(state => Object.keys(state.users)))
   );
-
+  console.timeEnd('augmentVSData');
   return {
     users: uniqueUserAddresses,
     processedData: globalTimestampStates,
     rewardBucketsTimeSeries,
     stackClaimableRewardData
   };
+};
+
+exports.augmentUserVSData = (userAddress, globalTimestampStates) => {
+  const finalTimestampState =
+    globalTimestampStates[globalTimestampStates.length - 1] ||
+    new GlobalTimestampState();
+
+  console.time('augmentUserVSData');
+  // can be lazy evaluated
+  globalTimestampStates.forEach(timestamp => {
+    const user = timestamp.users[userAddress];
+    if (!user) return;
+    const userAtMaturity = finalTimestampState.users[userAddress] || new User();
+    user.updateUserMaturityRewards(userAtMaturity);
+  });
+
+  // can be lazy evaluated
+  globalTimestampStates.forEach((timestampState, timestampIndex) => {
+    const user = timestampState.users[userAddress];
+    if (!user) return;
+    const prevTimestamp =
+      globalTimestampStates[timestampIndex - 1] || new GlobalTimestampState();
+    const userAtPrevTimestamp = prevTimestamp.users[userAddress] || new User();
+    const isAfterRewardPeriod = timestampState.rewardBuckets.length === 0;
+    const currentTimestampInMinutes = timestampState.timestamp;
+    const nextBucketGlobalReward = timestampState.rewardBuckets.reduce(
+      (accum, bucket) => {
+        return accum + bucket.initialRowan / bucket.duration;
+      },
+      0
+    );
+    user.updateUserMaturityDates(
+      userAtPrevTimestamp,
+      isAfterRewardPeriod,
+      currentTimestampInMinutes,
+      nextBucketGlobalReward
+    );
+  });
+
+  // fill in old timestamps with maturity date now that we have it
+  const lastTimestamp =
+    globalTimestampStates[globalTimestampStates.length - 1] ||
+    new GlobalTimestampState();
+
+  // can be lazy evaluated
+  globalTimestampStates.forEach(timestampState => {
+    const user = timestampState.users[userAddress];
+    if (!user) return;
+    const timestampDate = moment
+      .utc(START_DATETIME)
+      .add(timestampState.timestamp, 'm');
+    const lastUser = lastTimestamp.users[userAddress] || new User();
+    user.updateMaturityTimeProps(lastUser, timestampDate.valueOf());
+  });
+  console.timeEnd('augmentUserVSData');
 };

--- a/js/server/loaders/loadLiquidityMinersSnapshot.js
+++ b/js/server/loaders/loadLiquidityMinersSnapshot.js
@@ -22,7 +22,5 @@ module.exports.loadLiquidityMinersSnapshot = async function () {
         }
       `
     })
-  }).then(async r => {
-    return r.json();
   });
 };

--- a/js/server/loaders/loadValidatorsSnapshot.js
+++ b/js/server/loaders/loadValidatorsSnapshot.js
@@ -22,7 +22,7 @@ async function loadValidatorsSnapshot () {
         }
       `
     })
-  }).then(r => r.json());
+  });
 }
 
 module.exports = {

--- a/js/server/main.js
+++ b/js/server/main.js
@@ -4,11 +4,12 @@ const { getTimeIndex } = require('./util/getTimeIndex');
 const compression = require('compression');
 const fs = require('fs');
 // implements process.js in separate thread
-const { ProcessingHandler } = require('./processing-handler');
-
+// const { ProcessingHandler } = require('./processing-handler');
+const { BackgroundProcessor } = require('./process.childprocess.js');
 // require("./simple").createValidatorStakingTimeSeries();
 // interfaces with `./process.childprocess.js`
-const processingHandler = ProcessingHandler.init();
+// const processingHandler = ProcessingHandler.init();
+const processingHandler = BackgroundProcessor.startAsMainProcess();
 
 const port = process.env.PORT || 3000;
 const app = express();

--- a/js/server/process-vs.js
+++ b/js/server/process-vs.js
@@ -8,7 +8,6 @@ const {
   LIQUIDITY_MINING
 } = require('./constants/reward-program-types');
 
-// const history = {};
 /*
   Filter out deposit events after config.DEPOSIT_CUTOFF_DATETIME,
   but continue accruing rewards until config.END_OF_REWARD_ACCRUAL_DATETIME
@@ -18,22 +17,26 @@ function processVSGlobalState (
   timestamp,
   eventsByUser,
   getCurrentCommissionRateByValidatorStakeAddress,
-  rewardProgramType = VALIDATOR_STAKING
+  rewardProgramType = VALIDATOR_STAKING,
+  isSimulatedFutureInterval
 ) {
-  // if (history[timestamp]) {
-  //   return history[timestamp];
-  // }
   const { rewardBuckets, globalRewardAccrued } = processRewardBuckets(
     lastGlobalState.rewardBuckets,
     lastGlobalState.bucketEvent
   );
 
+  // console.time('processUserTickets');
   let users = processUserTickets(
     lastGlobalState.users,
     globalRewardAccrued,
-    getCurrentCommissionRateByValidatorStakeAddress
+    getCurrentCommissionRateByValidatorStakeAddress,
+    rewardProgramType,
+    isSimulatedFutureInterval
   );
+  // console.timeEnd('processUserTickets');
+  // console.time('processUserEvents');
   users = processUserEvents(users, eventsByUser, rewardProgramType);
+  // console.timeEnd('processUserEvents');
   if (rewardProgramType === VALIDATOR_STAKING) {
     users = calculateUserCommissions(users);
   }
@@ -43,32 +46,66 @@ function processVSGlobalState (
     rewardBuckets,
     users
   });
-  // history[timestamp] = globalState;
+  // console.time('processUserRewards');
+  processUserRewards(globalState);
+  // console.timeEnd('processUserRewards');
   return globalState;
 }
 
+function processUserRewards (state) {
+  const timestampTicketsAmountSum = state.updateTotalDepositedAmount();
+  // can be lazy evaluated
+  _.forEach(state.users, user => {
+    /*
+        Must be run on every user before `User#updateUserMaturityRewards`
+        `User#updateUserMaturityRewards` uses the rewards calulated here.
+        Must be run after `User#recalculateCurrentTotalCommissionsOnClaimableDelegatorRewards`
+        because `User#updateRewards` uses `User.currentTotalCommissionsOnClaimableDelegatorRewards`,
+        which is calculated in the former method.
+      */
+    user.updateRewards(timestampTicketsAmountSum);
+  });
+}
+const prevUserRewardsByProgramType = {
+  [VALIDATOR_STAKING]: {},
+  [LIQUIDITY_MINING]: {}
+};
 function processUserTickets (
   users,
   globalRewardAccrued,
-  getCurrentCommissionRateByValidatorStakeAddress
+  getCurrentCommissionRateByValidatorStakeAddress,
+  rewardProgramType,
+  isSimulatedFutureInterval
 ) {
   // process reward accruals and multiplier updates
-  const totalShares = _.sum(
-    _.flatten(
-      _.map(users, (user, address) => {
-        return user.tickets.map(ticket => ticket.amount);
-      })
-    )
-  );
-  const updatedUsers = _.mapValues(users, user => {
+  let totalShares = 0;
+  for (let addr in users) {
+    users[addr].tickets.forEach(t => {
+      totalShares += t.amount;
+    });
+  }
+  const prevUserRewards = prevUserRewardsByProgramType[rewardProgramType];
+  const updatedUsers = _.mapValues(users, (user, address) => {
+    // Don't deep clone users whose rewards can no longer change
+    if (
+      isSimulatedFutureInterval &&
+      prevUserRewards[address] ===
+        user.totalClaimableCommissionsAndClaimableRewards
+    ) {
+      // skip cloning
+      return user;
+    }
+    prevUserRewards[address] =
+      user.totalClaimableCommissionsAndClaimableRewards;
     return user.cloneWith({
       // reset each round because this is both incrementally calculated and based upon multiplier
       currentTotalCommissionsOnClaimableDelegatorRewards: 0,
       tickets: user.tickets.map(ticket => {
         const poolDominanceRatio = ticket.amount / (totalShares || 1);
         const rewardDelta = poolDominanceRatio * globalRewardAccrued;
+        const nextMul = ticket.mul + 0.75 / MULTIPLIER_MATURITY;
         return ticket.cloneWith({
-          mul: Math.min(ticket.mul + 0.75 / MULTIPLIER_MATURITY, 1),
+          mul: nextMul < 1 ? nextMul : 1,
           reward: ticket.reward + rewardDelta,
           rewardDelta: rewardDelta,
           poolDominanceRatio,
@@ -92,8 +129,11 @@ function processUserEvents (
   rewardProgramType = VALIDATOR_STAKING
 ) {
   const getUserByAddress = address => {
-    const user = users[address] || new User();
-    users[address] = user;
+    let user = users[address];
+    if (!user) {
+      user = new User();
+      users[address] = user;
+    }
     return user;
   };
   switch (rewardProgramType) {
@@ -118,7 +158,9 @@ function processUserEvents (
 }
 
 function processAccountEvents (userEvents, getUserByAddress) {
-  for (let uEvent of userEvents) {
+  const len = userEvents.length;
+  for (let i = 0; i < len; i++) {
+    const uEvent = userEvents[i];
     const user = getUserByAddress(uEvent.delegateAddress);
     if (uEvent.amount < 0) {
       user.withdrawStakeAsDelegator(uEvent, getUserByAddress);
@@ -129,18 +171,21 @@ function processAccountEvents (userEvents, getUserByAddress) {
 }
 
 function processRedelegationEvents (userEvents, getUserByAddress) {
-  userEvents = _.orderBy(userEvents, ['amount'], ['asc']);
   let withdrawalAmount = 0;
   let depositAmount = 0;
   const withdrawalEvents = [];
   const depositEvents = [];
-  for (let uEvent of userEvents) {
+
+  let uELen = userEvents.length;
+  for (let i = 0; i < uELen; i++) {
+    const uEvent = userEvents[i];
     if (uEvent.amount < 0) {
-      withdrawalAmount += Math.abs(uEvent.amount);
+      // turn amount to positive and add
+      withdrawalAmount += -uEvent.amount;
       withdrawalEvents.push(uEvent);
     }
     if (uEvent.amount > 0) {
-      depositAmount += Math.abs(uEvent.amount);
+      depositAmount += uEvent.amount;
       depositEvents.push(uEvent);
     }
   }
@@ -148,7 +193,9 @@ function processRedelegationEvents (userEvents, getUserByAddress) {
   let ticketsToRedelegate = [];
 
   let amountToRedelegate = Math.min(depositAmount, withdrawalAmount);
-  for (let wEvent of withdrawalEvents) {
+  const wELen = withdrawalEvents.length;
+  for (let i = 0; i < wELen; i++) {
+    const wEvent = withdrawalEvents[i];
     const user = getUserByAddress(wEvent.delegateAddress);
     const amountOfWithdrawalToRedelegate = Math.max(
       -amountToRedelegate,
@@ -179,10 +226,10 @@ function processRedelegationEvents (userEvents, getUserByAddress) {
   }
 
   /* 
-      Match the tickets with the highest remaining rewards
-      with the validators with the lowest commissions to maximize 
-      their gains over time.
-    */
+    Match the tickets with the highest remaining rewards
+    with the validators with the lowest commissions to maximize 
+    their gains over time.
+  */
   const sortedDepositEvents = _.sortBy(depositEvents, event => {
     return event.commission;
   });
@@ -193,7 +240,8 @@ function processRedelegationEvents (userEvents, getUserByAddress) {
     // make negative to sort in descending order
     return -remainingRatio;
   });
-  for (let dEvent of sortedDepositEvents) {
+  for (let i = 0; i < sortedDepositEvents.length; i++) {
+    const dEvent = sortedDepositEvents[i];
     const user = getUserByAddress(dEvent.delegateAddress);
     let nextTicketsToRedelegate = [];
     let amountToDeposit = dEvent.amount;

--- a/js/server/simplify.js
+++ b/js/server/simplify.js
@@ -2,7 +2,7 @@ const { graphqlRequest } = require('./loaders/graphqlRequest');
 const { loadValidatorsSnapshot } = require('./loaders/loadValidatorsSnapshot');
 const config = require('./config');
 async function createValidatorStakingTimeSeries () {
-  const snapshotRes = await loadValidatorsSnapshot();
+  const snapshotRes = await loadValidatorsSnapshot().then(r => r.json());
   const data = await graphqlRequest(`{
     events_audit
   }`);

--- a/js/server/types/GlobalTimestampState.js
+++ b/js/server/types/GlobalTimestampState.js
@@ -13,6 +13,18 @@ class GlobalTimestampState {
     this.totalDepositedAmount = totalDepositedAmount;
   }
 
+  updateTotalDepositedAmount () {
+    const users = this.users;
+    let timestampTicketsAmountSum = 0;
+    for (let addr in users) {
+      users[addr].tickets.forEach(t => {
+        timestampTicketsAmountSum += t.amount;
+      });
+    }
+    this.totalDepositedAmount = timestampTicketsAmountSum;
+    return timestampTicketsAmountSum;
+  }
+
   static fromJSON (props) {
     let next = Object.assign(new this(), props);
     next.users = Object.fromEntries(

--- a/js/server/types/User.js
+++ b/js/server/types/User.js
@@ -89,31 +89,37 @@ class User {
     let totalReward = 0;
     let totalClaimableReward = 0;
     // console.log(`Calculating updateRewards commissions correctly?`);
-    this.tickets.forEach(t => {
+    const tickets = this.tickets;
+    const length = tickets.length;
+    for (let i = 0; i < length; i++) {
+      const t = tickets[i];
+      const multiplier = t.mul;
+      const remainingMultiplier = 1 - multiplier;
       const totalValidatorCommissions = t.calculateTotalValidatorCommissions();
       const claimableReward =
-        t.reward * t.mul - totalValidatorCommissions * t.mul;
+        (t.reward - totalValidatorCommissions) * multiplier;
       const remainingReward =
-        (1 - t.mul) * t.reward - (1 - t.mul) * totalValidatorCommissions;
+        remainingMultiplier * t.reward -
+        remainingMultiplier * totalValidatorCommissions;
       const expectedReward = claimableReward + remainingReward;
       totalAmount += t.amount;
       totalReward += expectedReward;
       totalClaimableReward += claimableReward;
-    });
+    }
     this.totalDepositedAmount = totalAmount;
     this.totalClaimableRewardsOnDepositedAssets = totalClaimableReward;
+    const claimableOnWithdrawalsAndDeposits =
+      this.claimableRewardsOnWithdrawnAssets +
+      this.totalClaimableRewardsOnDepositedAssets;
+    const claimableCommissions = this.claimableCommissions;
     this.totalClaimableCommissionsAndClaimableRewards =
-      this.claimableRewardsOnWithdrawnAssets +
-      this.totalClaimableRewardsOnDepositedAssets +
-      this.claimableCommissions;
+      claimableOnWithdrawalsAndDeposits + claimableCommissions;
     this.totalAccruedCommissionsAndClaimableRewards =
-      this.claimableRewardsOnWithdrawnAssets +
-      this.totalClaimableRewardsOnDepositedAssets +
+      claimableOnWithdrawalsAndDeposits +
       this.currentTotalCommissionsOnClaimableDelegatorRewards +
-      this.claimableCommissions;
+      claimableCommissions;
     this.reservedReward = totalReward;
-    this.nextRewardShare =
-      this.totalDepositedAmount / timestampTicketsAmountSum;
+    this.nextRewardShare = totalAmount / timestampTicketsAmountSum;
   }
 
   updateUserMaturityDates (

--- a/js/server/types/UserTicket.js
+++ b/js/server/types/UserTicket.js
@@ -16,8 +16,9 @@ class UserTicket {
 
   calculateTotalValidatorCommissions () {
     let sum = 0;
-    for (let prop in this.commissionRewardsByValidator) {
-      sum += this.commissionRewardsByValidator[prop];
+    const rewards = this.commissionRewardsByValidator;
+    for (let prop in rewards) {
+      sum += rewards[prop];
     }
     return sum;
   }
@@ -73,9 +74,10 @@ class UserTicket {
   cloneWith (props) {
     let next = new UserTicket();
     next = Object.assign(Object.assign(next, this), props);
-    next.commissionRewardsByValidator = {
-      ...next.commissionRewardsByValidator
-    };
+    next.commissionRewardsByValidator = Object.assign(
+      {},
+      next.commissionRewardsByValidator
+    );
     return next;
   }
 

--- a/js/server/user.js
+++ b/js/server/user.js
@@ -1,5 +1,4 @@
 const { fetch } = require('cross-fetch');
-const { User } = require('./types');
 const { RateLimitProtector } = require('./util/RateLimitProtector');
 const config = require('./config');
 const clpFetch = new RateLimitProtector({ padding: 100 }).buildAsyncShield(
@@ -8,12 +7,14 @@ const clpFetch = new RateLimitProtector({ padding: 100 }).buildAsyncShield(
 );
 exports.getUserTimeSeriesData = (all, address) => {
   const rtn = all.map(timestampData => {
-    const userData = timestampData.users[address] || new User();
+    const userData = timestampData.users[address];
     // maintain compatibility with older dev branches until mainnet server is stable
     // return userData.totalAccruedCommissionsAndClaimableRewards;
     return {
       timestamp: timestampData.timestamp,
-      userClaimableReward: userData.totalAccruedCommissionsAndClaimableRewards
+      userClaimableReward: !userData
+        ? 0
+        : userData.totalAccruedCommissionsAndClaimableRewards
     };
   });
   rtn.shift();

--- a/js/server/util/vs-util.js
+++ b/js/server/util/vs-util.js
@@ -5,45 +5,44 @@ const { DelegateEvent } = require('../types');
 // Restructure snapshot address liquidity event entries into per-time interval aggregated event form
 // (see global-state.md for example)
 function remapVSAddresses (vaLAddresses) {
-  const mapped = _.map(
-    vaLAddresses,
-    ({ commission: commissionEvents, ...valAddressData }, valStakeAddress) => {
-      // Per data team, commission rates with value of zero are actually 0% commissions
-      // and shouldn't be ignored as in `processCommissionEvents(commissionEvents)`
-      // const commissionTimeIntervals = processCommissionEvents(commissionEvents);
-      const commissionTimeIntervals = commissionEvents;
+  const mapped = _.map(vaLAddresses, (valAddressData, valStakeAddress) => {
+    // Per data team, commission rates with value of zero are actually 0% commissions
+    // and shouldn't be ignored as in `processCommissionEvents(commissionEvents)`
+    // const commissionTimeIntervals = processCommissionEvents(commissionEvents);
+    const commissionTimeIntervals = valAddressData.commission;
 
-      /*
+    /*
         `rewardAddressDesignatedByValidator` is purposefully being set by the data team 
          as the first property key in the validator's delegate dictionary
       */
-      const delegates = Object.keys(valAddressData);
-      const rewardAddressDesignatedByValidator = delegates[0];
+    const delegates = Object.keys(valAddressData);
+    // remove 'commission' property
+    delegates.shift();
+    const rewardAddressDesignatedByValidator = delegates[0];
 
-      const valDelegateEvents = delegates
-        .map(delegateAddress => {
-          const delegateTimeIntervals = valAddressData[delegateAddress].rowan;
-          return delegateTimeIntervals
-            .map((amount, index) => {
-              const commissionRate = commissionTimeIntervals[index];
-              if (commissionRate < 0) {
-                console.log('COMMISSION RATE < 0. NEEDS HANDLING');
-              }
-              return DelegateEvent.fromJSON({
-                timestamp: (index + 1) * EVENT_INTERVAL_MINUTES,
-                commission: commissionRate,
-                amount,
-                delegateAddress,
-                validatorStakeAddress: valStakeAddress,
-                validatorRewardAddress: rewardAddressDesignatedByValidator
-              });
-            })
-            .filter(e => e.amount !== 0);
-        })
-        .filter(events => events.length !== 0);
-      return valDelegateEvents;
-    }
-  );
+    const valDelegateEvents = delegates
+      .map(delegateAddress => {
+        const delegateTimeIntervals = valAddressData[delegateAddress].rowan;
+        return delegateTimeIntervals
+          .map((amount, index) => {
+            const commissionRate = commissionTimeIntervals[index];
+            if (commissionRate < 0) {
+              console.log('COMMISSION RATE < 0. NEEDS HANDLING');
+            }
+            return DelegateEvent.fromJSON({
+              timestamp: (index + 1) * EVENT_INTERVAL_MINUTES,
+              commission: commissionRate,
+              amount,
+              delegateAddress,
+              validatorStakeAddress: valStakeAddress,
+              validatorRewardAddress: rewardAddressDesignatedByValidator
+            });
+          })
+          .filter(e => e.amount !== 0);
+      })
+      .filter(events => events.length !== 0);
+    return valDelegateEvents;
+  });
   const rawEvents = _.flattenDeep(mapped);
 
   let allTimeIntervalEvents = _.groupBy(rawEvents, 'timestamp');

--- a/js/src/App.js
+++ b/js/src/App.js
@@ -68,7 +68,7 @@ class App extends React.Component {
     this.setState({
       date: moment.utc(now),
       timestamp: Math.floor(
-        moment.duration(now.diff(START_DATETIME)).asMinutes() / 200
+        moment.duration(now.diff(moment.utc(START_DATETIME))).asMinutes() / 200
       )
     });
   }


### PR DESCRIPTION
Summary: 
* Added in-memory cache to store each past interval's state 
  * Initially cached entire timeseries, resulting in a >98% reduction in compute time. This doesn't work because it overwrites incoming snapshot data and simulated future states. However, the processor _will_ eventually converge to this level of efficiency.
  * Processor will now run _faster_ as the snapshot grows, because a larger percentage of it will be cachable, though this will likely be balanced out by an increase in users and tickets
* Implemented lazy evaluation for user-specific mutations in `augmentVSData.js`
* Disabled child process spawning
  * Now fast enough that we don't need to rotate child processes 
  * Improved load times due to the removal of extra JSON serialization & deserialization when passing data between parent & child processes 
* Decreased memory usage by recycling objects (instead of cloning) in timeseries when they are no longer changing 
  * Users & tickets in `process-vs.js/processUserTickets()`
* Added check to only reprocess when snapshot contains new data
* Replaced less-efficient loops with traditional `for` loops
* Decreased executions per snapshot interval by ~32
* Decreased compute time by 75%
* Decreased heap memory usage by 50%
* Decreased swap space usage by ~7GB